### PR TITLE
Enabled delete key in vim

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -13,6 +13,8 @@ set autoindent
 set smartindent
 " カーソルを行頭、行末で止まらないようにする
 set whichwrap=b,s,h,l,<,>,[,]
+" delete キーを有効にする
+set backspace=indent,eol,start
 
 "
 " エディターの表示について


### PR DESCRIPTION
https://unix.stackexchange.com/questions/186166/delete-key-doesnt-work-on-vim-insert-mode-for-deleting-previously-typed-conte