### PR TITLE
homebrew/cask-drivers was deprecated

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 tap "homebrew/bundle"
 tap "homebrew/cask"
-tap "homebrew/cask-drivers"
 tap "homebrew/cask-fonts"
 tap "homebrew/core"
 tap "jwbargsten/misc"

--- a/Brewfile_sapuri
+++ b/Brewfile_sapuri
@@ -1,7 +1,6 @@
 tap "c-bata/kube-prompt"
 tap "homebrew/bundle"
 tap "homebrew/cask"
-tap "homebrew/cask-drivers"
 tap "homebrew/cask-fonts"
 tap "homebrew/core"
 tap "jwbargsten/misc"


### PR DESCRIPTION
> Tapping homebrew/cask-drivers
Error: homebrew/cask-drivers was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-drivers has failed!